### PR TITLE
vifm dir preview, vicmd

### DIFF
--- a/.config/vifm/vifmrc
+++ b/.config/vifm/vifmrc
@@ -18,6 +18,9 @@ map bg :!setbg %f &<CR>
 nmap <space> tj
 nmap q ZQ
 fileviewer *.html,*.css,*.py,*.c,*.h,*.sh,*.diff,*.tex highlight -O ansi %c
+fileview */ tree %c -L 1 --dirsfirst
+
+set vicmd=$EDITOR
 
 set syscalls
 


### PR DESCRIPTION
Better looking (in my opinion) directory preview using `tree` package (0.11 MiB). You might want to adjust `tree` output to you liking e.g. using a higher tree or any of the other options depth but for me this looked fine.

Also was unable to open/edit files from within vifm. I fixed this by setting `vicmd=$EDITOR` but perhaps I'm missing a previous commit of yours on my system.
![image](https://user-images.githubusercontent.com/31730729/51146048-f1d3ff00-1855-11e9-902d-a2a6354f27ee.png)
